### PR TITLE
Improve release workflow and automation

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,0 +1,48 @@
+name: Promote Pre-release to Release
+
+on:
+  workflow_run:
+    workflows: [Release]
+    types:
+      - completed
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    
+    steps:
+      - name: Wait 24 hours
+        run: sleep 86400
+        
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Get latest pre-release
+        id: get_release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const response = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            if (!response.data.prerelease) {
+              console.log('Latest release is not a pre-release. Skipping.');
+              return;
+            }
+            return response.data;
+          result-encoding: string
+          
+      - name: Update to full release
+        if: steps.get_release.outputs.result != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const release = JSON.parse('${{ steps.get_release.outputs.result }}');
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.id,
+              prerelease: false
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - '*'
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   workflow_run:
     workflows: ["Build and Test"]
     types:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,22 +40,11 @@ jobs:
         run: |
           cd build/Build/Products/Release/
           zip -r mpvx.app.zip mpvx.app
-      - name: Create a Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release
+        uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          files: ./build/Build/Products/Release/mpvx.app.zip
           body_path: release_note.md
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
+          prerelease: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/Build/Products/Release/mpvx.app.zip
-          asset_name: mpvx.app.zip
-          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,10 @@ name: Release
 
 on:
   push:
-    tags: '[0-9]+.[0-9]+.[0-9]+'
+    tags:
+      - '*'
+    branches:
+      - main
   workflow_run:
     workflows: ["Build and Test"]
     types:
@@ -12,7 +15,7 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Generate Release Note
@@ -23,7 +26,8 @@ jobs:
           NEXT_TAG=`echo ${GITHUB_REF} | grep -E -o '[0-9]+\.[0-9]+\.[0-9]+'`
           echo "## Commits from ${NEXT_TAG} to ${LATEST_TAG}" | tee release_note.md
           git log --pretty="%h - %s" ${LATEST_TAG}..${NEXT_TAG} | tee -a release_note.md
-      - uses: maxim-lobanov/setup-xcode@v1
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
       - name: Setup
@@ -36,11 +40,17 @@ jobs:
             -configuration Release \
             -derivedDataPath build \
             -destination 'generic/platform=macOS'
-      - name: Zip the build
+      - name: Create zip
         run: |
           cd build/Build/Products/Release/
           zip -r mpvx.app.zip mpvx.app
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: mpvx.app.zip
+          path: ./build/Build/Products/Release/mpvx.app.zip
       - name: Release
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
           files: ./build/Build/Products/Release/mpvx.app.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,15 @@ jobs:
           wget ${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases\?per_page\=1 -O releases.json
           cat releases.json | jq
           LATEST_TAG=`cat releases.json | jq -r '.[0].tag_name'`
-          NEXT_TAG=`echo ${GITHUB_REF} | grep -E -o '[0-9]+\.[0-9]+\.[0-9]+'`
-          echo "## Commits from ${NEXT_TAG} to ${LATEST_TAG}" | tee release_note.md
-          git log --pretty="%h - %s" ${LATEST_TAG}..${NEXT_TAG} | tee -a release_note.md
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            NEXT_TAG=`echo ${GITHUB_REF} | grep -E -o '[0-9]+\.[0-9]+\.[0-9]+'`
+            echo "## Changes from ${LATEST_TAG} to ${NEXT_TAG}" | tee release_note.md
+            git log --pretty="%h - %s" ${LATEST_TAG}..${NEXT_TAG} | tee -a release_note.md
+          else
+            HEAD_HASH=`git rev-parse --short HEAD`
+            echo "## Changes from ${LATEST_TAG} to ${HEAD_HASH}" | tee release_note.md
+            git log --pretty="%h - %s" ${LATEST_TAG}..HEAD | tee -a release_note.md
+          fi
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,10 +54,15 @@ jobs:
           cd build/Build/Products/Release/
           zip -r mpvx.app.zip mpvx.app
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mpvx.app.zip
           path: ./build/Build/Products/Release/mpvx.app.zip
+      - name: Upload release note
+        uses: actions/upload-artifact@v4
+        with:
+          name: release_note.md
+          path: ./release_note.md
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Changes:
- Add new promote-release workflow
  - Automatically promotes pre-releases to full releases after 24 hours
  - Uses GitHub API to check and update release status
  - Only runs after successful release workflow completion

- Enhance release workflow
  - Add triggers for:
    - Tag pushes (any tag pattern)
    - Pushes to main branch
    - Pull requests to main branch
  - Improve release note generation:
    - Tag releases: show "Changes from [latest_tag] to [next_tag]"
    - Other events: show "Changes from [latest_tag] to [head_hash]"
  - Update dependencies:
    - actions/checkout@v4
    - actions/upload-artifact@v4
  - Add release note as workflow artifact
  - Better step organization and naming

The changes enable automatic pre-release promotion and provide better visibility into changes between versions, while maintaining the existing release functionality.